### PR TITLE
com.rest.elevenlabs 2.0.6

### DIFF
--- a/ElevenLabs/Packages/com.rest.elevenlabs/package.json
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/package.json
@@ -3,7 +3,7 @@
   "displayName": "ElevenLabs",
   "description": "A non-official Eleven Labs voice synthesis RESTful client.",
   "keywords": [],
-  "version": "2.0.5",
+  "version": "2.0.6",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs/releases",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.unity.sharp-zip-lib": "1.3.4-preview",
-    "com.utilities.rest": "2.1.0",
+    "com.utilities.rest": "2.1.4",
     "com.utilities.audio": "1.0.5"
   },
   "publishConfig": {

--- a/ElevenLabs/Packages/manifest.json
+++ b/ElevenLabs/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.24",
-    "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.ide.visualstudio": "2.0.20",
     "com.unity.test-framework": "1.3.5",
     "com.utilities.buildpipeline": "1.1.7"
   },

--- a/ElevenLabs/ProjectSettings/ProjectVersion.txt
+++ b/ElevenLabs/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.1f1
-m_EditorVersionWithRevision: 2022.3.1f1 (f18e0c1b5784)
+m_EditorVersion: 2022.3.7f1
+m_EditorVersionWithRevision: 2022.3.7f1 (b16b3b16c7a0)


### PR DESCRIPTION
- bump deps
- updated editor to 2022.3.7f1 LTS