### PR TITLE
com.rest.elevenlabs 3.2.7

### DIFF
--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
@@ -83,7 +83,7 @@ namespace ElevenLabs.Voices
 
                 foreach (var voice in voices)
                 {
-                    voiceSettingsTasks.Add(LocalGetVoiceSettings());
+                    voiceSettingsTasks.Add(LocalGetVoiceSettingsAsync());
     
                     async Task LocalGetVoiceSettingsAsync()
                     {

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
@@ -56,28 +56,44 @@ namespace ElevenLabs.Voices
         protected override string Root => "voices";
 
         /// <summary>
-        /// Gets a list of all available voices for a user.
+        /// Gets a list of all available voices for a user, and downloads all their settings.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns><see cref="IReadOnlyList{T}"/> of <see cref="Voice"/>s.</returns>
-        public async Task<IReadOnlyList<Voice>> GetAllVoicesAsync(CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Voice>> GetAllVoicesAsync(CancellationToken cancellationToken = default)
+        {
+            return GetAllVoicesAsync(true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a list of all available voices for a user.
+        /// </summary>
+        /// <param name="downloadSettings">Whether to download all settings for the voices.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns><see cref="IReadOnlyList{T}"/> of <see cref="Voice"/>s.</returns>
+        public async Task<IReadOnlyList<Voice>> GetAllVoicesAsync(bool downloadSettings, CancellationToken cancellationToken = default)
         {
             var response = await Rest.GetAsync(GetUrl(), new RestParameters(client.DefaultRequestHeaders), cancellationToken);
             response.Validate(EnableDebug);
             var voices = JsonConvert.DeserializeObject<VoiceList>(response.Body, ElevenLabsClient.JsonSerializationOptions).Voices;
-            var voiceSettingsTasks = new List<Task>();
 
-            foreach (var voice in voices)
+            if (downloadSettings)
             {
-                voiceSettingsTasks.Add(LocalGetVoiceSettings());
+                var voiceSettingsTasks = new List<Task>();
 
-                async Task LocalGetVoiceSettings()
+                foreach (var voice in voices)
                 {
-                    voice.Settings = await GetVoiceSettingsAsync(voice, cancellationToken).ConfigureAwait(true);
+                    voiceSettingsTasks.Add(LocalGetVoiceSettings());
+    
+                    async Task LocalGetVoiceSettings()
+                    {
+                        voice.Settings = await GetVoiceSettingsAsync(voice, cancellationToken).ConfigureAwait(true);
+                    }
                 }
+
+                await Task.WhenAll(voiceSettingsTasks).ConfigureAwait(true);
             }
 
-            await Task.WhenAll(voiceSettingsTasks).ConfigureAwait(true);
             return voices.ToList();
         }
 

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
@@ -85,7 +85,7 @@ namespace ElevenLabs.Voices
                 {
                     voiceSettingsTasks.Add(LocalGetVoiceSettings());
     
-                    async Task LocalGetVoiceSettings()
+                    async Task LocalGetVoiceSettingsAsync()
                     {
                         voice.Settings = await GetVoiceSettingsAsync(voice, cancellationToken).ConfigureAwait(true);
                     }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoicesEndpoint.cs
@@ -87,6 +87,7 @@ namespace ElevenLabs.Voices
     
                     async Task LocalGetVoiceSettingsAsync()
                     {
+                        await Awaiters.UnityMainThread;
                         voice.Settings = await GetVoiceSettingsAsync(voice, cancellationToken).ConfigureAwait(true);
                     }
                 }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/package.json
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/package.json
@@ -3,7 +3,7 @@
   "displayName": "ElevenLabs",
   "description": "A non-official Eleven Labs voice synthesis RESTful client.",
   "keywords": [],
-  "version": "3.2.6",
+  "version": "3.2.7",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs/releases",


### PR DESCRIPTION
Added `VoicesEndpoint.GetAllVoicesAsync(bool downloadSettings, CancellationToken)` because downloading the settings for 20+ voices takes quite a long time when such is not necessary in specific situations.