### PR TITLE
com.rest.elevenlabs 3.5.0

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -6,35 +6,71 @@ on:
     branches:
       - 'main'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     branches:
-      - '*'
+      - '**'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ (github.event_name == 'pull_request' || github.event.action == 'synchronize') }}
+  cancel-in-progress: ${{(github.event_name == 'pull_request' || github.event.action == 'synchronize')}}
 jobs:
   build:
-    permissions:
-      checks: write
-      pull-requests: write
+    name: ${{ matrix.os }} ${{ matrix.unity-version }} ${{ matrix.build-target }}
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15]
-        unity-versions: [2021.x, 2022.x, 6000.x]
-        include:
+        include: # for each os specify the build targets
           - os: ubuntu-latest
+            unity-version: 2022.x
+            build-target: Android
+          - os: ubuntu-latest
+            unity-version: 6000.x
+            build-target: Android
+          - os: ubuntu-latest
+            unity-version: 2022.x
             build-target: StandaloneLinux64
+          - os: ubuntu-latest
+            unity-version: 6000.x
+            build-target: StandaloneLinux64
+          - os: ubuntu-latest
+            unity-version: 2022.x
+            build-target: WebGL
+          - os: ubuntu-latest
+            unity-version: 6000.x
+            build-target: WebGL
           - os: windows-latest
+            unity-version: 2022.x
             build-target: StandaloneWindows64
-          - os: macos-15
+          - os: windows-latest
+            unity-version: 6000.x
+            build-target: StandaloneWindows64
+          - os: windows-latest
+            unity-version: 2022.x
+            build-target: WSAPlayer
+          - os: windows-latest
+            unity-version: 6000.x
+            build-target: WSAPlayer
+          - os: macos-latest
+            unity-version: 2022.x
+            build-target: iOS
+          - os: macos-latest
+            unity-version: 6000.x
+            build-target: iOS
+          - os: macos-latest
+            unity-version: 2022.x
+            build-target: StandaloneOSX
+          - os: macos-latest
+            unity-version: 6000.x
             build-target: StandaloneOSX
     steps:
       - uses: actions/checkout@v4
       - uses: RageAgainstThePixel/unity-setup@v1
         with:
-          unity-version: ${{ matrix.unity-versions }}
+          unity-version: ${{ matrix.unity-version }}
           build-targets: ${{ matrix.build-target }}
       - uses: RageAgainstThePixel/activate-unity-license@v1
         with:
@@ -56,5 +92,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: '${{ github.run_number }}.${{ github.run_attempt }}-${{ matrix.os }}-${{ matrix.unity-versions }}-${{ matrix.build-target }}-Artifacts'
+          name: '${{ github.run_number }}.${{ github.run_attempt }}-${{ matrix.os }}-${{ matrix.unity-version }}-${{ matrix.build-target }}-Artifacts'
           path: '${{ github.workspace }}/**/*.log'

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Documentation~/README.md
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Documentation~/README.md
@@ -18,6 +18,14 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Via Unity Package Manager and OpenUPM
 
+#### Terminal
+
+```bash
+openupm add com.rest.elevenlabs
+```
+
+#### Manual
+
 - Open your Unity project settings
 - Select the `Package Manager`
 ![scoped-registries](images/package-manager-scopes.png)
@@ -33,9 +41,11 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Via Unity Package Manager and Git url
 
+> [!WARNING]
+> This repo has dependencies on other repositories! You are responsible for adding these on your own.
+
 - Open your Unity Package Manager
 - Add package from git url: `https://github.com/RageAgainstThePixel/com.rest.elevenlabs.git#upm`
-  > Note: this repo has dependencies on other repositories! You are responsible for adding these on your own.
   - [com.utilities.async](https://github.com/RageAgainstThePixel/com.utilities.async)
   - [com.utilities.extensions](https://github.com/RageAgainstThePixel/com.utilities.extensions)
   - [com.utilities.audio](https://github.com/RageAgainstThePixel/com.utilities.audio)
@@ -45,7 +55,11 @@ The recommended installation method is though the unity package manager and [Ope
 
 ---
 
-## Documentation
+## [Documentation](https://rageagainstthepixel.github.io/ElevenLabs-DotNet)
+
+> Check out our new api docs!
+
+<https://rageagainstthepixel.github.io/ElevenLabs-DotNet>
 
 ### Table of Contents
 
@@ -290,7 +304,7 @@ var request = new TextToSpeechRequest(voice, message, model: Model.EnglishTurboV
 var voiceClip = await api.TextToSpeechEndpoint.StreamTextToSpeechAsync(request, partialClip =>
 {
     // Note: check demo scene for best practices
-    // on how to handle playback with OnAudioFilterRead
+    // on how to handle playback with StreamAudioSource.cs
     partialClips.Enqueue(partialClip);
 });
 ```

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Editor/ElevenLabsDashboard.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Editor/ElevenLabsDashboard.cs
@@ -1011,7 +1011,7 @@ namespace ElevenLabs.Editor
 
                 if (EditorGUI.EndChangeCheck())
                 {
-                    currentVoiceSettings = new VoiceSettings(voiceSettingsSliderValues.x, voiceSettingsSliderValues.y, useSpeakerBoost, voiceSettingsSliderValues.z);
+                    currentVoiceSettings = new VoiceSettings(voiceSettingsSliderValues.x, voiceSettingsSliderValues.y, voiceSettingsSliderValues.z, useSpeakerBoost);
                 }
 
                 EditorGUILayout.EndHorizontal();

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Common/GeneratedClip.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Common/GeneratedClip.cs
@@ -38,8 +38,6 @@ namespace ElevenLabs
             SampleRate = sampleRate;
         }
 
-        private readonly ReadOnlyMemory<byte> audioData;
-
         [SerializeField]
         private string id;
 
@@ -66,11 +64,15 @@ namespace ElevenLabs
         {
             get
             {
-                if (audioClip == null && !audioData.IsEmpty)
+                if (audioClip == null && !ClipData.IsEmpty)
                 {
-                    var pcmData = PCMEncoder.Decode(audioData.ToArray());
-                    audioClip = AudioClip.Create(Id, pcmData.Length, 1, SampleRate, false);
-                    audioClip.SetData(pcmData, 0);
+                    var samples = ClipSamples;
+
+                    if (samples is { Length: > 0 })
+                    {
+                        audioClip = AudioClip.Create(Id, samples.Length, 1, SampleRate, false);
+                        audioClip.SetData(samples, 0);
+                    }
                 }
 
                 if (audioClip == null)
@@ -98,7 +100,7 @@ namespace ElevenLabs
             {
                 if (!ClipData.IsEmpty)
                 {
-                    clipSamples ??= PCMEncoder.Decode(ClipData.ToArray());
+                    clipSamples ??= PCMEncoder.Decode(ClipData.ToArray(), PCMFormatSize.SixteenBit, SampleRate, AudioSettings.outputSampleRate);
                 }
                 else if (audioClip != null)
                 {

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechEndpoint.cs
@@ -283,6 +283,7 @@ namespace ElevenLabs.TextToSpeech
         private static async Task<string> SaveAudioToCache(byte[] audioData, string clipId, Voice voice, OutputFormat outputFormat, CacheFormat cacheFormat, CancellationToken cancellationToken)
         {
 #if PLATFORM_WEBGL
+            await Task.Yield();
             return null;
 #else
             if (cacheFormat == CacheFormat.None) { return null; }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechEndpoint.cs
@@ -104,12 +104,7 @@ namespace ElevenLabs.TextToSpeech
                 audioData = response.Data;
             }
 
-            string cachedPath = null;
-
-            if (request.CacheFormat != CacheFormat.None)
-            {
-                cachedPath = await SaveAudioToCache(audioData, clipId, request.Voice, request.OutputFormat, request.CacheFormat, cancellationToken).ConfigureAwait(true);
-            }
+            var cachedPath = await SaveAudioToCache(audioData, clipId, request.Voice, request.OutputFormat, request.CacheFormat, cancellationToken).ConfigureAwait(true);
 
             return new VoiceClip(clipId, request.Text, request.Voice, new ReadOnlyMemory<byte>(audioData), request.OutputFormat.GetSampleRate(), cachedPath)
             {
@@ -183,12 +178,7 @@ namespace ElevenLabs.TextToSpeech
             }
 
             var audioData = request.WithTimestamps ? accumulatedPCMData!.ToArray() : response.Data;
-            string cachedPath = null;
-
-            if (request.CacheFormat != CacheFormat.None)
-            {
-                cachedPath = await SaveAudioToCache(audioData, clipId, request.Voice, request.OutputFormat, request.CacheFormat, cancellationToken).ConfigureAwait(true);
-            }
+            var cachedPath = await SaveAudioToCache(audioData, clipId, request.Voice, request.OutputFormat, request.CacheFormat, cancellationToken).ConfigureAwait(true);
 
             return new VoiceClip(clipId, request.Text, request.Voice, new ReadOnlyMemory<byte>(audioData), request.OutputFormat.GetSampleRate(), cachedPath)
             {
@@ -292,6 +282,11 @@ namespace ElevenLabs.TextToSpeech
 
         private static async Task<string> SaveAudioToCache(byte[] audioData, string clipId, Voice voice, OutputFormat outputFormat, CacheFormat cacheFormat, CancellationToken cancellationToken)
         {
+#if PLATFORM_WEBGL
+            return null;
+#else
+            if (cacheFormat == CacheFormat.None) { return null; }
+
             string extension;
             AudioType audioType;
 
@@ -312,7 +307,6 @@ namespace ElevenLabs.TextToSpeech
                         extension = "ogg";
                         audioType = AudioType.OGGVORBIS;
                         break;
-                    case CacheFormat.None:
                     default:
                         throw new ArgumentOutOfRangeException(nameof(cacheFormat), cacheFormat, null);
                 }
@@ -343,6 +337,7 @@ namespace ElevenLabs.TextToSpeech
             }
 
             return cachedPath;
+#endif // PLATFORM_WEBGL
         }
 
     }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechRequest.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechRequest.cs
@@ -222,7 +222,7 @@ namespace ElevenLabs.TextToSpeech
         public int? Seed { get; }
 
         [Preserve]
-        [JsonProperty("apply_text_normalization")]
+        [JsonProperty("apply_text_normalization", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string ApplyTextNormalization { get; }
     }
 }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechRequest.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/TextToSpeech/TextToSpeechRequest.cs
@@ -12,6 +12,27 @@ namespace ElevenLabs.TextToSpeech
     [Preserve]
     public sealed class TextToSpeechRequest
     {
+        [Obsolete("use new .ctr overload")]
+        public TextToSpeechRequest(
+            Voice voice,
+            string text,
+            Encoding encoding,
+            VoiceSettings voiceSettings,
+            OutputFormat outputFormat,
+            int? optimizeStreamingLatency,
+            Model model = null,
+            string previousText = null,
+            string nextText = null,
+            string[] previousRequestIds = null,
+            string[] nextRequestIds = null,
+            string languageCode = null,
+            CacheFormat cacheFormat = CacheFormat.Wav,
+            bool withTimestamps = false)
+          : this(voice, text, encoding, voiceSettings, outputFormat, model, cacheFormat, previousText, nextText, previousRequestIds, nextRequestIds, languageCode, withTimestamps)
+        {
+            OptimizeStreamingLatency = optimizeStreamingLatency;
+        }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -32,27 +53,55 @@ namespace ElevenLabs.TextToSpeech
         /// Output format of the generated audio.<br/>
         /// Defaults to <see cref="OutputFormat.MP3_44100_128"/>
         /// </param>
-        /// <param name="optimizeStreamingLatency">
-        /// Optional, You can turn on latency optimizations at some cost of quality.
-        /// The best possible final latency varies by model.<br/>
-        /// Possible values:<br/>
-        /// 0 - default mode (no latency optimizations)<br/>
-        /// 1 - normal latency optimizations (about 50% of possible latency improvement of option 3)<br/>
-        /// 2 - strong latency optimizations (about 75% of possible latency improvement of option 3)<br/>
-        /// 3 - max latency optimizations<br/>
-        /// 4 - max latency optimizations, but also with text normalizer turned off for even more latency savings
-        /// (best latency, but can mispronounce e.g. numbers and dates).
+        /// <param name="previousText">
+        /// The text that came before the text of the current request.
+        /// Can be used to improve the speech’s continuity when concatenating together multiple generations or
+        /// to influence the speech’s continuity in the current generation.
         /// </param>
-        /// <param name="previousText"></param>
-        /// <param name="nextText"></param>
-        /// <param name="previousRequestIds"></param>
-        /// <param name="nextRequestIds"></param>
+        /// <param name="nextText">
+        /// The text that comes after the text of the current request.
+        /// Can be used to improve the speech’s continuity when concatenating together multiple generations or
+        /// to influence the speech’s continuity in the current generation.
+        /// </param>
+        /// <param name="previousRequestIds">
+        /// A list of request_id of the samples that were generated before this generation.
+        /// Can be used to improve the speech’s continuity when splitting up a large task into multiple requests.
+        /// The results will be best when the same model is used across the generations. In case both previous_text and previous_request_ids is send,
+        /// previous_text will be ignored. A maximum of 3 request_ids can be send.
+        /// </param>
+        /// <param name="nextRequestIds">
+        /// A list of request_id of the samples that come after this generation.
+        /// next_request_ids is especially useful for maintaining the speech’s continuity when regenerating a sample that has had some audio quality issues.
+        /// For example, if you have generated 3 speech clips, and you want to improve clip 2,
+        /// passing the request id of clip 3 as a next_request_id (and that of clip 1 as a previous_request_id)
+        /// will help maintain natural flow in the combined speech.
+        /// The results will be best when the same model is used across the generations.
+        /// In case both next_text and next_request_ids is send, next_text will be ignored.
+        /// A maximum of 3 request_ids can be send.
+        /// </param>
         /// <param name="languageCode">
         /// Optional, Language code (ISO 639-1) used to enforce a language for the model. Currently only <see cref="Model.TurboV2_5"/> supports language enforcement.
         /// For other models, an error will be returned if language code is provided.
         /// </param>
-        /// <param name="cacheFormat"></param>
-        /// <param name="withTimestamps"></param>
+        /// <param name="cacheFormat">
+        /// The audio format to save the audio in.
+        /// Defaults to <see cref="CacheFormat.Wav"/>
+        /// </param>
+        /// <param name="withTimestamps">
+        /// Generate speech from text with precise character-level timing information for audio-text synchronization.
+        /// </param>
+        /// <param name="seed">
+        /// If specified, our system will make a best effort to sample deterministically,
+        /// such that repeated requests with the same seed and parameters should return the same result.
+        /// Determinism is not guaranteed. Must be integer between 0 and 4294967295.
+        /// </param>
+        /// <param name="applyTextNormalization">
+        /// This parameter controls text normalization with three modes: ‘auto’ (null), ‘on’ (true), and ‘off’ (false).
+        /// When set to ‘null’, the system will automatically decide whether to apply text normalization (e.g., spelling out numbers).
+        /// With ‘true’, text normalization will always be applied,
+        /// while with ‘false’, it will be skipped.
+        /// Cannot be turned on for ‘eleven_turbo_v2_5’ model.
+        /// </param>
         [Preserve]
         public TextToSpeechRequest(
             Voice voice,
@@ -60,15 +109,16 @@ namespace ElevenLabs.TextToSpeech
             Encoding encoding = null,
             VoiceSettings voiceSettings = null,
             OutputFormat outputFormat = OutputFormat.MP3_44100_128,
-            int? optimizeStreamingLatency = null,
             Model model = null,
+            CacheFormat cacheFormat = CacheFormat.Wav,
             string previousText = null,
             string nextText = null,
             string[] previousRequestIds = null,
             string[] nextRequestIds = null,
             string languageCode = null,
-            CacheFormat cacheFormat = CacheFormat.Wav,
-            bool withTimestamps = false)
+            bool withTimestamps = false,
+            int? seed = null,
+            bool? applyTextNormalization = null)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
@@ -91,7 +141,6 @@ namespace ElevenLabs.TextToSpeech
             Voice = string.IsNullOrWhiteSpace(voice) ? Voice.Adam : voice;
             VoiceSettings = voiceSettings ?? voice.Settings;
             OutputFormat = outputFormat;
-            OptimizeStreamingLatency = optimizeStreamingLatency;
             PreviousText = previousText;
             NextText = nextText;
             if (previousRequestIds?.Length > 3)
@@ -107,6 +156,12 @@ namespace ElevenLabs.TextToSpeech
             LanguageCode = languageCode;
             CacheFormat = cacheFormat;
             WithTimestamps = withTimestamps;
+            Seed = seed;
+
+            if (applyTextNormalization.HasValue)
+            {
+                ApplyTextNormalization = applyTextNormalization.Value ? "on" : "off";
+            }
         }
 
         [Preserve]
@@ -135,6 +190,7 @@ namespace ElevenLabs.TextToSpeech
 
         [Preserve]
         [JsonIgnore]
+        [Obsolete("Deprecated")]
         public int? OptimizeStreamingLatency { get; }
 
         [Preserve]
@@ -145,16 +201,10 @@ namespace ElevenLabs.TextToSpeech
         [JsonProperty("next_text")]
         public string NextText { get; }
 
-        /// <remarks>
-        /// A maximum of three next or previous history item ids can be sent
-        /// </remarks>
         [Preserve]
         [JsonProperty("previous_request_ids")]
         public string[] PreviousRequestIds { get; }
 
-        /// <remarks>
-        /// A maximum of three next or previous history item ids can be sent
-        /// </remarks>
         [Preserve]
         [JsonProperty("next_request_ids")]
         public string[] NextRequestIds { get; }
@@ -166,5 +216,13 @@ namespace ElevenLabs.TextToSpeech
         [Preserve]
         [JsonIgnore]
         public bool WithTimestamps { get; }
+
+        [Preserve]
+        [JsonProperty("seed")]
+        public int? Seed { get; }
+
+        [Preserve]
+        [JsonProperty("apply_text_normalization")]
+        public string ApplyTextNormalization { get; }
     }
 }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoiceSettings.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoiceSettings.cs
@@ -11,6 +11,16 @@ namespace ElevenLabs.Voices
     [Serializable]
     public sealed class VoiceSettings
     {
+        [Obsolete("use new .ctr overload")]
+        public VoiceSettings(
+            float stability,
+            float similarityBoost,
+            bool speakerBoost,
+            float style)
+            : this(stability, similarityBoost, style, speakerBoost)
+        {
+        }
+
         [Preserve]
         [JsonConstructor]
         public VoiceSettings(
@@ -25,16 +35,6 @@ namespace ElevenLabs.Voices
             Style = style;
             SpeakerBoost = speakerBoost;
             Speed = speed;
-        }
-
-        [Obsolete("use new .ctr overload")]
-        public VoiceSettings(
-            [JsonProperty("stability")] float stability,
-            [JsonProperty("similarity_boost")] float similarityBoost,
-            [JsonProperty("speaker_boost")] bool speakerBoost,
-            [JsonProperty("style")] float style)
-          : this(stability, similarityBoost, style, speakerBoost)
-        {
         }
 
         [Range(0f, 1f)]

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoiceSettings.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Runtime/Voices/VoiceSettings.cs
@@ -14,15 +14,27 @@ namespace ElevenLabs.Voices
         [Preserve]
         [JsonConstructor]
         public VoiceSettings(
-            [JsonProperty("stability")] float stability = .75f,
-            [JsonProperty("similarity_boost")] float similarityBoost = .75f,
-            [JsonProperty("speaker_boost")] bool speakerBoost = true,
-            [JsonProperty("style")] float style = 0.45f)
+            [JsonProperty("stability")] float stability = 0.75f,
+            [JsonProperty("similarity_boost")] float similarityBoost = 0.75f,
+            [JsonProperty("style")] float style = 0.45f,
+            [JsonProperty("use_speaker_boost")] bool speakerBoost = true,
+            [JsonProperty("speed")] float speed = 1f)
         {
             Stability = stability;
             SimilarityBoost = similarityBoost;
             Style = style;
             SpeakerBoost = speakerBoost;
+            Speed = speed;
+        }
+
+        [Obsolete("use new .ctr overload")]
+        public VoiceSettings(
+            [JsonProperty("stability")] float stability,
+            [JsonProperty("similarity_boost")] float similarityBoost,
+            [JsonProperty("speaker_boost")] bool speakerBoost,
+            [JsonProperty("style")] float style)
+          : this(stability, similarityBoost, style, speakerBoost)
+        {
         }
 
         [Range(0f, 1f)]
@@ -70,6 +82,17 @@ namespace ElevenLabs.Voices
         {
             get => speakerBoost;
             set => speakerBoost = value;
+        }
+
+        [SerializeField]
+        private float speed = 1f;
+
+        [Preserve]
+        [JsonProperty("speed", DefaultValueHandling = DefaultValueHandling.Include)]
+        public float Speed
+        {
+            get => speed;
+            set => speed = value;
         }
     }
 }

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Samples~/TextToSpeech/TextToSpeechDemo.unity
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Samples~/TextToSpeech/TextToSpeechDemo.unity
@@ -226,6 +226,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1232673084}
   - component: {fileID: 1232673086}
+  - component: {fileID: 1232673087}
   - component: {fileID: 1232673085}
   m_Layer: 0
   m_Name: Demo
@@ -264,8 +265,8 @@ MonoBehaviour:
   configuration: {fileID: 0}
   debug: 1
   voice:
-    name: Bella
-    id: EXAVITQu4vr4xnSDxMaL
+    name: Aria
+    id: 9BWtsMINqrJLrRacOk9x
   message: What is Lorem Ipsum? Lorem Ipsum is simply dummy text of the printing
     and typesetting industry. Lorem Ipsum has been the industry's standard dummy
     text ever since the 1500s, when an unknown printer took a galley of type and
@@ -274,7 +275,7 @@ MonoBehaviour:
     It was popularised in the 1960s with the release of Letraset sheets containing
     Lorem Ipsum passages, and more recently with desktop publishing software like
     Aldus PageMaker including versions of Lorem Ipsum.
-  audioSource: {fileID: 1232673086}
+  streamAudioSource: {fileID: 1232673087}
 --- !u!82 &1232673086
 AudioSource:
   m_ObjectHideFlags: 0
@@ -371,6 +372,19 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &1232673087
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232673082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b2317b29e6eb934f9f1cd50d682e019, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioSource: {fileID: 1232673086}
 --- !u!1 &1655310072
 GameObject:
   m_ObjectHideFlags: 0

--- a/ElevenLabs/Packages/com.rest.elevenlabs/Tests/Test_Fixture_04_TextToSpeechEndpoint.cs
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/Tests/Test_Fixture_04_TextToSpeechEndpoint.cs
@@ -105,7 +105,7 @@ namespace ElevenLabs.Tests
                 voice: voice,
                 text: "Příliš žluťoučký kůň úpěl ďábelské ódy",
                 voiceSettings: defaultVoiceSettings,
-                model: Models.Model.TurboV2_5,
+                model: Models.Model.FlashV2_5,
                 outputFormat: OutputFormat.MP3_44100_192,
                 cacheFormat: CacheFormat.None,
                 languageCode: "cs");

--- a/ElevenLabs/Packages/com.rest.elevenlabs/package.json
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/package.json
@@ -3,7 +3,7 @@
   "displayName": "ElevenLabs",
   "description": "A non-official Eleven Labs voice synthesis RESTful client.",
   "keywords": [],
-  "version": "3.4.3",
+  "version": "3.5.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.rest.elevenlabs/releases",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "com.utilities.rest": "3.3.0",
-    "com.utilities.encoder.ogg": "4.0.1",
-    "com.utilities.encoder.wav": "2.0.2"
+    "com.utilities.encoder.ogg": "4.2.0",
+    "com.utilities.encoder.wav": "2.2.0"
   },
   "samples": [
     {

--- a/ElevenLabs/Packages/com.rest.elevenlabs/package.json
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "com.utilities.rest": "3.3.0",
+    "com.utilities.audio": "2.2.1",
     "com.utilities.encoder.ogg": "4.2.0",
     "com.utilities.encoder.wav": "2.2.0"
   },

--- a/ElevenLabs/Packages/com.rest.elevenlabs/package.json
+++ b/ElevenLabs/Packages/com.rest.elevenlabs/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
-    "com.utilities.rest": "3.3.0",
+    "com.utilities.rest": "3.3.1",
     "com.utilities.audio": "2.2.1",
     "com.utilities.encoder.ogg": "4.2.0",
     "com.utilities.encoder.wav": "2.2.0"

--- a/ElevenLabs/Packages/manifest.json
+++ b/ElevenLabs/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.test-framework": "1.3.5",
-    "com.utilities.buildpipeline": "1.5.7"
+    "com.utilities.buildpipeline": "1.6.0"
   },
   "scopedRegistries": [
     {

--- a/ElevenLabs/ProjectSettings/ProjectSettings.asset
+++ b/ElevenLabs/ProjectSettings/ProjectSettings.asset
@@ -161,6 +161,7 @@ PlayerSettings:
     Android: com.rest.elevenlabs
     Lumin: com.rest.elevenlabs
     Standalone: com.rest.elevenlabs
+    WebGL: com.rest.elevenlabs
     iPhone: com.rest.elevenlabs
   buildNumber:
     Standalone: 0
@@ -275,7 +276,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 15cd37f5ffbadef4ea67ff67bf624e28, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:

--- a/ElevenLabs/ProjectSettings/ProjectSettings.asset
+++ b/ElevenLabs/ProjectSettings/ProjectSettings.asset
@@ -280,196 +280,239 @@ PlayerSettings:
   - m_BuildTarget: 
     m_Icons:
     - serializedVersion: 2
-      m_Icon: {fileID: 2800000, guid: 15cd37f5ffbadef4ea67ff67bf624e28, type: 3}
+      m_Icon: {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 128
       m_Height: 128
       m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 180
       m_Height: 180
       m_Kind: 0
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 120
       m_Height: 120
       m_Kind: 0
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 167
       m_Height: 167
       m_Kind: 0
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 152
       m_Height: 152
       m_Kind: 0
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 76
       m_Height: 76
       m_Kind: 0
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 120
       m_Height: 120
       m_Kind: 3
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 80
       m_Height: 80
       m_Kind: 3
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 80
       m_Height: 80
       m_Kind: 3
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 3
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 87
       m_Height: 87
       m_Kind: 1
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 58
       m_Height: 58
       m_Kind: 1
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 29
       m_Height: 29
       m_Kind: 1
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 58
       m_Height: 58
       m_Kind: 1
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 29
       m_Height: 29
       m_Kind: 1
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 60
       m_Height: 60
       m_Kind: 2
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 2
       m_SubKind: iPhone
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 40
       m_Height: 40
       m_Kind: 2
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 20
       m_Height: 20
       m_Kind: 2
       m_SubKind: iPad
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 1024
       m_Height: 1024
       m_Kind: 4
       m_SubKind: App Store
   - m_BuildTarget: Android
     m_Icons:
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 432
       m_Height: 432
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 324
       m_Height: 324
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 216
       m_Height: 216
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 162
       m_Height: 162
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 108
       m_Height: 108
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 81
       m_Height: 81
       m_Kind: 2
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 192
       m_Height: 192
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 144
       m_Height: 144
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 96
       m_Height: 96
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 72
       m_Height: 72
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 48
       m_Height: 48
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 36
       m_Height: 36
       m_Kind: 1
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 192
       m_Height: 192
       m_Kind: 0
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 144
       m_Height: 144
       m_Kind: 0
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 96
       m_Height: 96
       m_Kind: 0
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 72
       m_Height: 72
       m_Kind: 0
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 48
       m_Height: 48
       m_Kind: 0
       m_SubKind: 
-    - m_Textures: []
+    - m_Textures:
+      - {fileID: 2800000, guid: 5b71cbcaf078a8e44a5c96dcd24376d5, type: 3}
       m_Width: 36
       m_Height: 36
       m_Kind: 0

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Via Unity Package Manager and OpenUPM
 
+#### Terminal
+
+```bash
+openupm add com.rest.elevenlabs
+```
+
+#### Manual
+
 - Open your Unity project settings
 - Select the `Package Manager`
 ![scoped-registries](ElevenLabs/Packages/com.rest.elevenlabs/Documentation~/images/package-manager-scopes.png)
@@ -33,9 +41,11 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Via Unity Package Manager and Git url
 
+> [!WARNING]
+> This repo has dependencies on other repositories! You are responsible for adding these on your own.
+
 - Open your Unity Package Manager
 - Add package from git url: `https://github.com/RageAgainstThePixel/com.rest.elevenlabs.git#upm`
-  > Note: this repo has dependencies on other repositories! You are responsible for adding these on your own.
   - [com.utilities.async](https://github.com/RageAgainstThePixel/com.utilities.async)
   - [com.utilities.extensions](https://github.com/RageAgainstThePixel/com.utilities.extensions)
   - [com.utilities.audio](https://github.com/RageAgainstThePixel/com.utilities.audio)
@@ -294,7 +304,7 @@ var request = new TextToSpeechRequest(voice, message, model: Model.EnglishTurboV
 var voiceClip = await api.TextToSpeechEndpoint.StreamTextToSpeechAsync(request, partialClip =>
 {
     // Note: check demo scene for best practices
-    // on how to handle playback with OnAudioFilterRead
+    // on how to handle playback with StreamAudioSource.cs
     partialClips.Enqueue(partialClip);
 });
 ```


### PR DESCRIPTION
- added TextToSpeechRequest.ctr overload
  - added seed property
  - added applyTextNormalization property
  - removed depricated optimizeStreamingLatency property
- added VoiceSettings.ctr overload
  - added speed property
- fix audio decoding bug in GeneratedClip
- added TextToSpeechAsync overload with Func(VoiceClip, Task) callback
- updated TextToSpeechDemo with StreamAudioSource example
- updated deps
  - com.utilities.rest -> 3.3.1
  - com.utilities.audio -> 2.2.1
  - com.utilities.encoder.wav -> 2.2.0
  - com.utilities.encoder.ogg -> 4.2.0